### PR TITLE
Get and apply multiple crop information

### DIFF
--- a/imagecropview/src/main/java/com/naver/android/helloyako/imagecrop/view/ImageCropView.java
+++ b/imagecropview/src/main/java/com/naver/android/helloyako/imagecrop/view/ImageCropView.java
@@ -1222,4 +1222,29 @@ public class ImageCropView extends ImageView {
     public boolean isChangingScale() {
         return isChangingScale;
     }
+
+    public float[] getPositionInfo() {
+        float[] vals = new float[9];
+        mSuppMatrix.getValues(vals);
+        return  vals;
+    }
+
+    public void applyPositionInfo(float[] values) {
+        mBitmapChanged = true;
+        applyValues(values);
+        requestLayout();
+    }
+
+    private void applyValues(float[] values) {
+        if (LOG_ENABLED) {
+            Log.i(LOG_TAG, "Matrix updated based on previous position info");
+        }
+
+        mSuppMatrix = new Matrix();
+        mSuppMatrix.setValues(values);
+
+        setImageMatrix(getImageViewMatrix());
+        postInvalidate();
+    }
+
 }


### PR DESCRIPTION
when i use saveState to save the second crop information, the first saved state will be changed.
it can only save one state.

i found version 1.1.0 works well to save multiple crop information. 
and i also want to use outsideLayerColor attrs which is released in version 1.2.2?  (so i can't use version 1.1.0)
can those method in 1.1.0 be usable again in future?

https://github.com/naver/android-imagecropview/issues/10
https://github.com/naver/android-imagecropview/pull/11